### PR TITLE
Install build-essential for GDB in case when gcc, g++ or make aren't installed.

### DIFF
--- a/gdb/playbook.yaml
+++ b/gdb/playbook.yaml
@@ -2,4 +2,8 @@
 - hosts: 127.0.0.1
   sudo: true
   tasks:
-    - apt: name=gdb state=present
+    - name: Install dependencies
+      apt: name={{item}} state=present
+      with_items:
+        - build-essential
+        - gdb


### PR DESCRIPTION
https://codio.myjetbrains.com/youtrack/issue/codio-8147